### PR TITLE
implemented option to generate non-persistent randomized mac address.

### DIFF
--- a/service/java/com/android/server/wifi/ClientModeImpl.java
+++ b/service/java/com/android/server/wifi/ClientModeImpl.java
@@ -4277,8 +4277,10 @@ public class ClientModeImpl extends StateMachine {
 
                     reportConnectionAttemptStart(config, mTargetRoamBSSID,
                             WifiMetricsProto.ConnectionEvent.ROAM_UNRELATED);
-                    if (config.macRandomizationSetting
+                    if ((config.macRandomizationSetting
                             == WifiConfiguration.RANDOMIZATION_PERSISTENT
+                            || config.macRandomizationSetting
+                            == WifiConfiguration.RANDOMIZATION_ALWAYS)
                             && mConnectedMacRandomzationSupported) {
                         configureRandomizedMacAddress(config);
                     } else {

--- a/service/java/com/android/server/wifi/WifiConfigManager.java
+++ b/service/java/com/android/server/wifi/WifiConfigManager.java
@@ -1064,14 +1064,18 @@ public class WifiConfigManager {
         // Update randomized MAC address according to stored map
         final String key = config.getSsidAndSecurityTypeString();
         // If the key is not found in the current store, then it means this network has never been
-        // seen before. So add it to store.
-        if (!mRandomizedMacAddressMapping.containsKey(key)) {
+        // seen before. 
+        // Or if RANDOMIZATION_ALWAYS is toggled
+        // So add it to store.
+        if (!mRandomizedMacAddressMapping.containsKey(key) ||
+               config.macRandomizationSetting == WifiConfiguration.RANDOMIZATION_ALWAYS) {
             mRandomizedMacAddressMapping.put(key,
                     config.getOrCreateRandomizedMacAddress().toString());
-        } else { // Otherwise read from the store and set the WifiConfiguration
+        } else {
             try {
-                config.setRandomizedMacAddress(
-                        MacAddress.fromString(mRandomizedMacAddressMapping.get(key)));
+                // read from the store and set the WifiConfiguration
+                    config.setRandomizedMacAddress(
+                            MacAddress.fromString(mRandomizedMacAddressMapping.get(key)));
             } catch (IllegalArgumentException e) {
                 Log.e(TAG, "Error creating randomized MAC address from stored value.");
                 mRandomizedMacAddressMapping.put(key,

--- a/service/java/com/android/server/wifi/WifiConfigurationUtil.java
+++ b/service/java/com/android/server/wifi/WifiConfigurationUtil.java
@@ -221,7 +221,7 @@ public class WifiConfigurationUtil {
     public static boolean hasMacRandomizationSettingsChanged(WifiConfiguration existingConfig,
             WifiConfiguration newConfig) {
         if (existingConfig == null) {
-            return newConfig.macRandomizationSetting != WifiConfiguration.RANDOMIZATION_PERSISTENT;
+            return newConfig.macRandomizationSetting != WifiConfiguration.RANDOMIZATION_ALWAYS;
         }
         return newConfig.macRandomizationSetting != existingConfig.macRandomizationSetting;
     }


### PR DESCRIPTION
To trigger re-generation of randomized mac addressed for an already
connected AP. User simply has to toggle on/off wifi.
Otherwise, on re-connection, a new randomized mac address also gets
generated.

Companion Patchset:
https://github.com/GrapheneOS/platform_frameworks_base/pull/20
https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/6

Tested on Pixel 3A Sargo