### PR TITLE
PORT: add support for always generating new random MAC

### DIFF
--- a/libs/WifiTrackerLib/src/com/android/wifitrackerlib/StandardWifiEntry.java
+++ b/libs/WifiTrackerLib/src/com/android/wifitrackerlib/StandardWifiEntry.java
@@ -309,7 +309,7 @@ public class StandardWifiEntry extends WifiEntry {
 
     @Override
     public String getMacAddress() {
-        if (mWifiConfig == null || getPrivacy() != PRIVACY_RANDOMIZED_MAC) {
+        if (mWifiConfig == null || getPrivacy() == PRIVACY_DEVICE_MAC) {
             final String[] factoryMacs = mWifiManager.getFactoryMacAddresses();
             if (factoryMacs.length > 0) {
                 return factoryMacs[0];
@@ -538,11 +538,19 @@ public class StandardWifiEntry extends WifiEntry {
     @Override
     @Privacy
     public int getPrivacy() {
-        if (mWifiConfig != null
-                && mWifiConfig.macRandomizationSetting == WifiConfiguration.RANDOMIZATION_NONE) {
-            return PRIVACY_DEVICE_MAC;
+        if (mWifiConfig != null) {
+            switch(mWifiConfig.macRandomizationSetting) {
+                case WifiConfiguration.RANDOMIZATION_NONE:
+                    return PRIVACY_DEVICE_MAC;
+                case WifiConfiguration.RANDOMIZATION_PERSISTENT:
+                    return PRIVACY_RANDOMIZED_MAC;
+                case WifiConfiguration.RANDOMIZATION_ALWAYS:
+                    return PRIVACY_FULLY_RANDOMIZED_MAC;
+                default:
+                    return PRIVACY_FULLY_RANDOMIZED_MAC;
+            }
         } else {
-            return PRIVACY_RANDOMIZED_MAC;
+            return PRIVACY_FULLY_RANDOMIZED_MAC;
         }
     }
 
@@ -551,9 +559,7 @@ public class StandardWifiEntry extends WifiEntry {
         if (!canSetPrivacy()) {
             return;
         }
-
-        mWifiConfig.macRandomizationSetting = privacy == PRIVACY_RANDOMIZED_MAC
-                ? WifiConfiguration.RANDOMIZATION_PERSISTENT : WifiConfiguration.RANDOMIZATION_NONE;
+        mWifiConfig.macRandomizationSetting = translatePrivacyToWifiConfigurationValues(privacy);
         mWifiManager.save(mWifiConfig, null /* listener */);
     }
 
@@ -894,5 +900,17 @@ public class StandardWifiEntry extends WifiEntry {
     @Override
     String getNetworkSelectionDescription() {
         return Utils.getNetworkSelectionDescription(getWifiConfiguration());
+    }
+
+    private static int translatePrivacyToWifiConfigurationValues(int privacy_value) {
+        switch(privacy_value) {
+            case PRIVACY_FULLY_RANDOMIZED_MAC:
+                return WifiConfiguration.RANDOMIZATION_ALWAYS;
+            case PRIVACY_RANDOMIZED_MAC:
+                return WifiConfiguration.RANDOMIZATION_PERSISTENT;
+            case PRIVACY_DEVICE_MAC:
+                return WifiConfiguration.RANDOMIZATION_NONE;
+        }
+        return WifiConfiguration.RANDOMIZATION_ALWAYS;
     }
 }

--- a/libs/WifiTrackerLib/src/com/android/wifitrackerlib/WifiEntry.java
+++ b/libs/WifiTrackerLib/src/com/android/wifitrackerlib/WifiEntry.java
@@ -148,6 +148,7 @@ public abstract class WifiEntry implements Comparable<WifiEntry> {
     public static final int PRIVACY_DEVICE_MAC = 0;
     public static final int PRIVACY_RANDOMIZED_MAC = 1;
     public static final int PRIVACY_UNKNOWN = 2;
+    public static final int PRIVACY_FULLY_RANDOMIZED_MAC = 100;
 
     @Retention(RetentionPolicy.SOURCE)
     @IntDef(value = {

--- a/service/java/com/android/server/wifi/ClientModeImpl.java
+++ b/service/java/com/android/server/wifi/ClientModeImpl.java
@@ -6441,7 +6441,8 @@ public class ClientModeImpl extends StateMachine {
         }
 
         if (isConnectedMacRandomizationEnabled()) {
-            if (config.macRandomizationSetting == WifiConfiguration.RANDOMIZATION_PERSISTENT) {
+            if (config.macRandomizationSetting == WifiConfiguration.RANDOMIZATION_PERSISTENT || 
+                    config.macRandomizationSetting == WifiConfiguration.RANDOMIZATION_ALWAYS) {
                 configureRandomizedMacAddress(config);
             } else {
                 setCurrentMacToFactoryMac(config);
@@ -6478,7 +6479,7 @@ public class ClientModeImpl extends StateMachine {
                 (config.getIpAssignment() == IpConfiguration.IpAssignment.STATIC);
         final boolean isUsingMacRandomization =
                 config.macRandomizationSetting
-                        == WifiConfiguration.RANDOMIZATION_PERSISTENT
+                        > WifiConfiguration.RANDOMIZATION_NONE
                         && isConnectedMacRandomizationEnabled();
         if (mVerboseLoggingEnabled) {
             final String key = config.getKey();

--- a/service/java/com/android/server/wifi/WifiConfigManager.java
+++ b/service/java/com/android/server/wifi/WifiConfigManager.java
@@ -425,9 +425,14 @@ public class WifiConfigManager {
      */
     public boolean shouldUseAggressiveRandomization(WifiConfiguration config) {
         if (!isMacRandomizationSupported()
-                || config.macRandomizationSetting != WifiConfiguration.RANDOMIZATION_PERSISTENT) {
+                || config.macRandomizationSetting < WifiConfiguration.RANDOMIZATION_PERSISTENT) {
             return false;
         }
+
+        if (config.macRandomizationSetting == WifiConfiguration.RANDOMIZATION_ALWAYS) {
+            return true;
+        }
+
         if (mFrameworkFacade.getIntegerSetting(mContext,
                 ENHANCED_MAC_RANDOMIZATION_FEATURE_FORCE_ENABLE_FLAG, 0) == 1) {
             return true;
@@ -545,8 +550,10 @@ public class WifiConfigManager {
      * @return the updated MacAddress
      */
     private MacAddress updateRandomizedMacIfNeeded(WifiConfiguration config) {
-        boolean shouldUpdateMac = config.randomizedMacExpirationTimeMs
-                < mClock.getWallClockMillis();
+        boolean shouldUpdateMac = (config.randomizedMacExpirationTimeMs
+                < mClock.getWallClockMillis() || 
+                config.macRandomizationSetting == WifiConfiguration.RANDOMIZATION_ALWAYS);
+
         if (!shouldUpdateMac) {
             return config.getRandomizedMacAddress();
         }
@@ -1606,7 +1613,7 @@ public class WifiConfigManager {
     public boolean isInFlakyRandomizationSsidHotlist(int networkId) {
         WifiConfiguration config = getConfiguredNetwork(networkId);
         return config != null
-                && config.macRandomizationSetting == WifiConfiguration.RANDOMIZATION_PERSISTENT
+                && config.macRandomizationSetting != WifiConfiguration.RANDOMIZATION_NONE
                 && mDeviceConfigFacade.getRandomizationFlakySsidHotlist().contains(config.SSID);
     }
 

--- a/service/java/com/android/server/wifi/WifiConfigurationUtil.java
+++ b/service/java/com/android/server/wifi/WifiConfigurationUtil.java
@@ -203,7 +203,7 @@ public class WifiConfigurationUtil {
     public static boolean hasMacRandomizationSettingsChanged(WifiConfiguration existingConfig,
             WifiConfiguration newConfig) {
         if (existingConfig == null) {
-            return newConfig.macRandomizationSetting != WifiConfiguration.RANDOMIZATION_PERSISTENT;
+            return newConfig.macRandomizationSetting != WifiConfiguration.RANDOMIZATION_ALWAYS;
         }
         return newConfig.macRandomizationSetting != existingConfig.macRandomizationSetting;
     }

--- a/service/java/com/android/server/wifi/WifiMetrics.java
+++ b/service/java/com/android/server/wifi/WifiMetrics.java
@@ -1444,7 +1444,7 @@ public class WifiMetrics {
             if (config != null) {
                 mCurrentConnectionEvent.mConnectionEvent.useRandomizedMac =
                         config.macRandomizationSetting
-                        == WifiConfiguration.RANDOMIZATION_PERSISTENT;
+                        != WifiConfiguration.RANDOMIZATION_NONE;
                 mCurrentConnectionEvent.mConnectionEvent.useAggressiveMac =
                         mWifiConfigManager.shouldUseAggressiveRandomization(config);
                 mCurrentConnectionEvent.mConnectionEvent.connectionNominator =
@@ -3841,7 +3841,7 @@ public class WifiMetrics {
                 if (config.isPasspoint()) {
                     mWifiLogProto.numPasspointNetworks++;
                 }
-                if (config.macRandomizationSetting == WifiConfiguration.RANDOMIZATION_PERSISTENT) {
+                if (config.macRandomizationSetting != WifiConfiguration.RANDOMIZATION_NONE) {
                     mWifiLogProto.numSavedNetworksWithMacRandomization++;
                 }
             }


### PR DESCRIPTION
To trigger re-generation of randomized MAC addressed for an already
connected AP. User simply has to toggle on/off wifi. Otherwise, on
re-connection, a new randomized MAC address also gets generated.